### PR TITLE
Fix possibility to stuck on shutdown.

### DIFF
--- a/cmd/aardappel/main.go
+++ b/cmd/aardappel/main.go
@@ -172,6 +172,9 @@ func doMain(ctx context.Context, config configInit.Config, srcDb *ydb.Driver, ds
 	}
 
 	lockExecutor := func(fn func(context.Context, table.Session, table.Transaction) error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return locker.ExecuteUnderLock(ctx, fn)
 	}
 


### PR DESCRIPTION
* locker library does not allow to pass cancelled context to ExecuteUnderLock method